### PR TITLE
답변 완료 화면에서 수정 플로우를 추가합니다.

### DIFF
--- a/Ahobsu.xcodeproj/project.pbxproj
+++ b/Ahobsu.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		60712E24E822658E9354E63A3F9106B0 /* AnswerWeek.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA405C08D4F44F9263A48346F2987B99 /* AnswerWeek.swift */; };
 		63EC707B702F70546022F5268B33D4DB /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3538D8E89CC16EFFB5AC4C42018359B2 /* SplashView.swift */; };
 		63F562C392EFF08575084D7FCCADFAA2 /* AnswerQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54897E54114C299DC791A8C87484A2A3 /* AnswerQuestion.swift */; };
+		6467E11026BB6888000D24D6 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6467E10F26BB6888000D24D6 /* Config.swift */; };
 		64B4402494D785C7BB7D436D61074A60 /* FileModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F903F42F6F06846B7D7ED623C2A1188 /* FileModel.swift */; };
 		65376F7BF8D9119E53ECDDA6E709F31F /* Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4095D0A15B937B14DD0B1E9243252123 /* Keyboard.swift */; };
 		6675DA914AB268309BC9390ED0487711 /* SignInWithAppleDelegates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21028E6C7A9E457DA7D2AC3F90B21995 /* SignInWithAppleDelegates.swift */; };
@@ -215,6 +216,7 @@
 		60F4E2286FCBCCB712F8DB007B559FFE /* GenderCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenderCardView.swift; sourceTree = "<group>"; };
 		627D69417FFDB9370F8C58945F570844 /* Networking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
 		633C286DB1ED5ACD4A094B0C2E099E28 /* SignUpGenderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpGenderView.swift; sourceTree = "<group>"; };
+		6467E10F26BB6888000D24D6 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		651E668CEFCDFA43412FDC79B18A8094 /* RoundedCorner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoundedCorner.swift; sourceTree = "<group>"; };
 		65D4FC3176B2D6A6A22B58C671DDED5E /* AlbumIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumIntent.swift; sourceTree = "<group>"; };
 		65FC12FC50520F836F645BDBCD11824A /* AhobsuAPIConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AhobsuAPIConfig.swift; sourceTree = "<group>"; };
@@ -470,6 +472,14 @@
 			path = Splash;
 			sourceTree = "<group>";
 		};
+		6467E10E26BB6879000D24D6 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				6467E10F26BB6888000D24D6 /* Config.swift */,
+			);
+			path = Config;
+			sourceTree = "<group>";
+		};
 		66B06056EC6306CB95E43D55EBB54D56 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -589,6 +599,7 @@
 		9B7A173A97D0463CC8BB42133ED4F71D /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				6467E10E26BB6879000D24D6 /* Config */,
 				7E5C3DDDBE5EFBA929F62DEC19887F7C /* DatePickerView */,
 				F5F6576FBA47C51DFDB637EE28AD2829 /* Fonts */,
 				E11A3E80387511066A7D202CB221F153 /* ActivityIndicator.swift */,
@@ -1108,6 +1119,7 @@
 				FE9A5C5ED84DA12E738F1C023FE43495 /* ActivityIndicator.swift in Sources */,
 				549FCCECAA918667E1EC72B0793D05BB /* AhobsuAPI.swift in Sources */,
 				38390EE92CA3042159C07B381F522900 /* AhobsuAPIConfig.swift in Sources */,
+				6467E11026BB6888000D24D6 /* Config.swift in Sources */,
 				08952E7F3061C2AC361F20FCFA8C7366 /* AhobsuProvider.swift in Sources */,
 				4E6E2023D386BF88CDB2A8DE5A7BC4F9 /* AlbumIntent.swift in Sources */,
 				E7AF816713E6C4CC1C1497D73187C56D /* AlbumView.swift in Sources */,

--- a/Ahobsu/Model/Answer.swift
+++ b/Ahobsu/Model/Answer.swift
@@ -73,12 +73,15 @@ extension Answer {
         return formatter.date(from: date)
     }
     func isTodayAnswer() -> Bool {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = .withFullDate
+        formatter.timeZone = TimeZone.current
         
-        let todayStr = formatter.string(from: Date())
+        let nowDate = Date()
+        let modifiedDate = Calendar.current.date(byAdding: .hour, value: -MISSION_INIT_TIME.hour, to: nowDate)!
         
-        return self.date == todayStr
+        let todayDateString = formatter.string(from: modifiedDate)
+        return self.date == todayDateString
     }
 }
 

--- a/Ahobsu/MotiViews/Album/AlbumView.swift
+++ b/Ahobsu/MotiViews/Album/AlbumView.swift
@@ -118,7 +118,7 @@ struct PartsCombinedAnswer: View {
     }
     
     var body: some View {
-        NavigationLink(destination: AnswerCompleteView(answers)) {
+        NavigationLink(destination: AnswerCompleteView(models: answers.compactMap({ $0 }))) {
             ZStack {
                 ForEach(self.answers.compactMap { $0?.file.cardUrl },
                         id: \.self,

--- a/Ahobsu/MotiViews/Album/AlbumWeekView.swift
+++ b/Ahobsu/MotiViews/Album/AlbumWeekView.swift
@@ -22,7 +22,7 @@ struct AlbumWeekView: View {
             DayWeekView(isFills: answers.map { $0 != nil })
                 .frame(height: 72, alignment: .center)
             ZStack {
-                NavigationLink(destination: AnswerCompleteView(answers)) {
+                NavigationLink(destination: AnswerCompleteView(models: answers.compactMap({ $0 }))) {
                     CardView(innerLine: true)
                         .aspectRatio(257.0 / 439.0, contentMode: .fit)
                         .padding([.horizontal], 59)

--- a/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteCardView.swift
+++ b/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteCardView.swift
@@ -19,13 +19,21 @@ struct AnswerCompleteCardView: View, Identifiable {
         if let answer = self.answer {
             switch answer.getAnswerType() {
                 case .essay:
-                    return AnyView(AnswerComplete_Essay(title: answer.mission.title, text: answer.content ?? ""))
+                    return AnyView(AnswerComplete_Essay(
+                                    title: answer.mission.title,
+                                    text: answer.content ?? "")
+                    )
                 case .camera:
-                    return AnyView(AnswerComplete_Camera(title: answer.mission.title, imageURL: answer.imageUrl ?? ""))
+                    return AnyView(AnswerComplete_Camera(
+                                    title: answer.mission.title,
+                                    imageURL: answer.imageUrl ?? "")
+                    )
                 case .essayCamera:
-                    return AnyView(AnswerComplete_EssayCamera(title: answer.mission.title,
-                                                              text: answer.content ?? "",
-                                                              imageURL: answer.imageUrl ?? ""))
+                    return AnyView(AnswerComplete_EssayCamera(
+                                    title: answer.mission.title,
+                                    text: answer.content ?? "",
+                                    imageURL: answer.imageUrl ?? "")
+                    )
             }
         } else {
             return AnyView(Text(""))
@@ -33,11 +41,18 @@ struct AnswerCompleteCardView: View, Identifiable {
     }
     
     var body: some View {
-        VStack {
-            contentView
-                .frame(minWidth: 0, maxWidth: .infinity, minHeight: UIScreen.main.bounds.height - (CGFloat.safeAreaTop + CGFloat.safeAreaTop + 72), maxHeight: UIScreen.main.bounds.height - (CGFloat.safeAreaTop + CGFloat.safeAreaTop + 72))
-                .clipped()
-                .padding([.bottom], 32.0)
+        GeometryReader { geometry in
+            VStack {
+                contentView
+                    .frame(
+                        minWidth: 0,
+                        maxWidth: .infinity,
+                        minHeight: UIScreen.main.bounds.height - (geometry.safeAreaInsets.top * 2 + 72),
+                        maxHeight: UIScreen.main.bounds.height - (geometry.safeAreaInsets.top * 2 + 72)
+                    )
+                    .clipped()
+                    .padding([.bottom], 32.0)
+            }
         }
     }
     

--- a/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
+++ b/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
@@ -49,7 +49,7 @@ struct AnswerCompleteView: View {
     
     @State var currentPage = 0
     
-    init(_ models: [Answer]) {
+    init(models: [Answer]) {
         self.models = models
         
         self.viewControllers = self.models.map({

--- a/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
+++ b/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
@@ -84,14 +84,51 @@ struct AnswerCompleteView: View {
     
     @ViewBuilder
     var btnEdit: some View {
-        if self.models[self.currentPage].date == self.getTodayDateString() {
-            Button(action: {
-                self.presentationMode.wrappedValue.dismiss()
-            }, label: {
+        let currentAnswer = self.models[self.currentPage]
+        
+        if currentAnswer.date == self.getTodayDateString() {
+            Button(action: {}, label: {
                 HStack {
-                    Image("icRewriteNormal")
-                        .aspectRatio(contentMode: .fit)
-                        .foregroundColor(.white)
+                    if currentAnswer.getAnswerType() == Answer.AnswerType.essay {
+                        NavigationLink(destination: AnswerQuestionEssayView(
+                                        text: currentAnswer.content ?? "",
+                            missionData: currentAnswer.mission,
+                                        isEdit: true,
+                                        answerId: currentAnswer.id
+                        )) {
+                            Image("icRewriteNormal")
+                                .aspectRatio(contentMode: .fit)
+                                .foregroundColor(.white)
+                        }.environment(\.isEnabled, !currentAnswer.mission.title.isEmpty)
+                    }
+                    
+                    if currentAnswer.getAnswerType() == Answer.AnswerType.camera {
+                        NavigationLink(destination: AnswerQuestionImageView(
+                            image: UIImage(data: ImageLoader(urlString: currentAnswer.imageUrl ?? "").data ?? Data()),
+                            missionData: currentAnswer.mission,
+                                        isEdit: true,
+                                        answerId: currentAnswer.id,
+                                        imageUrl: currentAnswer.imageUrl
+                        )) {
+                            Image("icRewriteNormal")
+                                .aspectRatio(contentMode: .fit)
+                                .foregroundColor(.white)
+                        }.environment(\.isEnabled, !currentAnswer.mission.title.isEmpty)
+                    }
+                    
+                    if currentAnswer.getAnswerType() == Answer.AnswerType.essayCamera {
+                        NavigationLink(destination: AnswerQuestionImageEssayView(
+                            image: UIImage(data: ImageLoader(urlString: currentAnswer.imageUrl ?? "").data ?? Data()),
+                                        text: currentAnswer.content ?? "",
+                            missionData: currentAnswer.mission,
+                                        isEdit: true,
+                            answerId: currentAnswer.id
+                        )) {
+                            Image("icRewriteNormal")
+                                .aspectRatio(contentMode: .fit)
+                                .foregroundColor(.white)
+                        }.environment(\.isEnabled, !currentAnswer.mission.title.isEmpty)
+                    }
                 }
             })
         }
@@ -142,7 +179,7 @@ struct AnswerCompleteView_Previews: PreviewProvider {
     static var previews: some View {
         
         return Group {
-            AnswerCompleteView(Answer.dummyCardView())
+            AnswerCompleteView(models: Answer.dummyCardView())
                 .previewDevice(PreviewDevice(rawValue: "iPhone 8"))
                 .previewDisplayName("iPhone 8")
         }

--- a/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
+++ b/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
@@ -108,7 +108,7 @@ struct AnswerCompleteView: View {
                 .foregroundColor(Color(.rosegold))
                 .font(.custom("IropkeBatangOTFM", size: 20.0))
                 .lineSpacing(16.0)
-        }(), trailingItem: EmptyView()) {
+        }(), trailingItem: btnEdit) {
             ZStack {
                 BackgroundView()
                     .edgesIgnoringSafeArea([.vertical])

--- a/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
+++ b/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
@@ -49,10 +49,8 @@ struct AnswerCompleteView: View {
     
     @State var currentPage = 0
     
-    init(_ model: [Answer?]) {
-        self.models = model.compactMap({ $0 })
-        
-        print(self.models)
+    init(_ models: [Answer]) {
+        self.models = models
         
         self.viewControllers = self.models.map({
             let controller = UIHostingController(rootView: AnswerCompleteCardView(answer: $0))

--- a/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
+++ b/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
@@ -66,8 +66,15 @@ struct AnswerCompleteView: View {
         formatter.formatOptions = .withFullDate
         formatter.timeZone = TimeZone.current
         
-        let todayDateString = formatter.string(from: Date())
+        let nowDate = Date()
+        let modifiedDate = Calendar.current.date(byAdding: .hour, value: -MISSION_INIT_TIME.hour, to: nowDate)!
+        
+        let todayDateString = formatter.string(from: modifiedDate)
         return todayDateString
+    }
+    
+    func isEditable(currentAnswer: Answer) -> Bool {
+        return currentAnswer.date == self.getTodayDateString()
     }
     
     var btnBack: some View {
@@ -86,7 +93,7 @@ struct AnswerCompleteView: View {
     var btnEdit: some View {
         let currentAnswer = self.models[self.currentPage]
         
-        if currentAnswer.date == self.getTodayDateString() {
+        if self.isEditable(currentAnswer: currentAnswer) {
             Button(action: {}, label: {
                 HStack {
                     if currentAnswer.getAnswerType() == Answer.AnswerType.essay {

--- a/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
+++ b/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
@@ -84,6 +84,24 @@ struct AnswerCompleteView: View {
         })
     }
     
+    @ViewBuilder
+    var btnEdit: some View {
+        if self.models[self.currentPage].date == self.getTodayDateString() {
+            Button(action: {
+                self.presentationMode.wrappedValue.dismiss()
+            }, label: {
+                HStack {
+                    Image("icRewriteNormal")
+                        .aspectRatio(contentMode: .fit)
+                        .foregroundColor(.white)
+                }
+            })
+        }
+        else {
+            EmptyView()
+        }
+    }
+    
     var body: some View {
         NavigationMaskingView(titleItem: {
             Text(dateToString(models[currentPage].dateForDate))

--- a/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
+++ b/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
@@ -63,7 +63,16 @@ struct AnswerCompleteView: View {
         })
     }
     
-    var btnBack : some View {
+    func getTodayDateString() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = .withFullDate
+        formatter.timeZone = TimeZone.current
+        
+        let todayDateString = formatter.string(from: Date())
+        return todayDateString
+    }
+    
+    var btnBack: some View {
         Button(action: {
             self.presentationMode.wrappedValue.dismiss()
         }, label: {

--- a/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
+++ b/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
@@ -129,7 +129,8 @@ struct AnswerCompleteView: View {
                                         text: currentAnswer.content ?? "",
                             missionData: currentAnswer.mission,
                                         isEdit: true,
-                            answerId: currentAnswer.id
+                            answerId: currentAnswer.id,
+                            imageUrl: currentAnswer.imageUrl
                         )) {
                             Image("icRewriteNormal")
                                 .aspectRatio(contentMode: .fit)

--- a/Ahobsu/MotiViews/Common/Config/Config.swift
+++ b/Ahobsu/MotiViews/Common/Config/Config.swift
@@ -1,0 +1,21 @@
+//
+//  Config.swift
+//  Ahobsu
+//
+//  Created by 김선재 on 2021/08/05.
+//  Copyright © 2021 ahobsu. All rights reserved.
+//
+
+import Foundation
+
+class InitTime {
+    var hour: Int
+    var minute: Int
+    
+    init(hour: Int, minute: Int) {
+        self.hour = hour
+        self.minute = minute
+    }
+}
+
+let MISSION_INIT_TIME = InitTime(hour: 5, minute: 0)

--- a/Ahobsu/MotiViews/Diary/DiaryView.swift
+++ b/Ahobsu/MotiViews/Diary/DiaryView.swift
@@ -68,7 +68,7 @@ struct DiaryView: View {
                                 } else {
                                     EmptyView()
                                 }
-                                NavigationLink(destination: AnswerCompleteView([answer])) {
+                                NavigationLink(destination: AnswerCompleteView(models: [answer])) {
                                     DiaryRowView(answer: answer)
                                 }
                                 .id(answer.id)

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerInsertViews/AnswerCameraView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerInsertViews/AnswerCameraView.swift
@@ -22,7 +22,7 @@ struct AnswerCameraView: View {
     @State var text = ""
 
     
-    var missonData: Mission
+    var missionData: Mission
     @State var isNetworking: Bool = false
     @State var answerRegisteredActive: Bool = false
     
@@ -35,7 +35,7 @@ struct AnswerCameraView: View {
                             VStack {
                                 if image == nil {
                                     HStack {
-                                        Text(missonData.title)
+                                        Text(missionData.title)
                                             .font(.custom("IropkeBatangOTFM", size: 24.0))
                                             .lineSpacing(6)
                                             .foregroundColor(Color(.rosegold))
@@ -45,7 +45,7 @@ struct AnswerCameraView: View {
                                     Spacer()
                                     Image("imgCam")
                                 } else {
-                                    if missonData.isContent {
+                                    if missionData.isContent {
                                         //                            ZStack {
                                         CardView(innerLine: true)
                                             .overlay(
@@ -132,7 +132,7 @@ struct AnswerCameraView: View {
                                         {
                                             MainButton(action: { self.registerCameraAnswer() },
                                                        title: "제출하기")
-                                        }.environment(\.isEnabled, !(missonData.isContent && text.isEmpty))
+                                        }.environment(\.isEnabled, !(missionData.isContent && text.isEmpty))
                                     }
                                     
                                 }
@@ -168,8 +168,8 @@ extension AnswerCameraView {
         guard let image = image else { return }
         self.isNetworking = true
         
-        let content: String? = missonData.isContent ? text : nil
-        AhobsuProvider.registerAnswer(missionId: missonData.id,
+        let content: String? = missionData.isContent ? text : nil
+        AhobsuProvider.registerAnswer(missionId: missionData.id,
                                       contentOrNil: content,
                                       imageOrNil: image,
                                       completion: { (response) in
@@ -187,6 +187,6 @@ extension AnswerCameraView {
 
 //struct AnswerCameraView_Previews: PreviewProvider {
 //    static var previews: some View {
-//        AnswerCameraView(missonData: Mission(id: 1, title: "", isContent: true, isImage: true))
+//        AnswerCameraView(missionData: Mission(id: 1, title: "", isContent: true, isImage: true))
 //    }
 //}

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerInsertViews/AnswerInsertCamaraView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerInsertViews/AnswerInsertCamaraView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct AnswerInsertCamaraView: View {
     @Binding var image: UIImage?
-    var missonData: Mission
+    var missionData: Mission
     
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerInsertViews/AnswerInsertEssayCameraView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerInsertViews/AnswerInsertEssayCameraView.swift
@@ -16,7 +16,7 @@ struct AnswerInsertEssayCameraView: View {
     
     @State var text = ""
     
-    var missonData: Mission
+    var missionData: Mission
     @State var isNetworking: Bool = false
     @State var answerRegisteredActive: Bool = false
     
@@ -28,7 +28,7 @@ struct AnswerInsertEssayCameraView: View {
                 ZStack {
                     VStack {
                         HStack {
-                            Text(missonData.title)
+                            Text(missionData.title)
                                 .font(.custom("IropkeBatangOTFM", size: 24.0))
                                 .lineSpacing(6)
                                 .foregroundColor(Color(.rosegold))
@@ -97,7 +97,7 @@ struct AnswerInsertEssayCameraView: View {
         guard let image = image else { return }
         self.isNetworking = true
         
-        AhobsuProvider.registerAnswer(missionId: missonData.id,
+        AhobsuProvider.registerAnswer(missionId: missionData.id,
                                       contentOrNil: text,
                                       imageOrNil: image,
                                       completion: { wrapper in

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerInsertViews/AnswerInsertEssayView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerInsertViews/AnswerInsertEssayView.swift
@@ -23,7 +23,7 @@ struct AnswerInsertEssayView: View {
     
     @State var text = ""
     
-    var missonData: Mission
+    var missionData: Mission
     
     var body: some View {
         NavigationMaskingView(titleItem: Text("답변하기"), trailingItem: EmptyView()) {
@@ -33,7 +33,7 @@ struct AnswerInsertEssayView: View {
                 ZStack {
                     VStack {
                         HStack {
-                            Text(missonData.title)
+                            Text(missionData.title)
                                 .font(.custom("IropkeBatangOTFM", size: 24.0))
                                 .lineSpacing(6)
                                 .foregroundColor(Color(.rosegold))
@@ -92,7 +92,7 @@ struct AnswerInsertEssayView: View {
     }
     
     private func requestAnswer() {
-        //        AhobsuProvider.provider.requestPublisher(.registerAnswer(missionId: missonData.id,
+        //        AhobsuProvider.provider.requestPublisher(.registerAnswer(missionId: missionData.id,
         //                                                                 contentOrNil: text,
         //                                                                 imageOrNil: nil))
         //            .map { $0.statusCode == 201 }
@@ -105,7 +105,7 @@ struct AnswerInsertEssayView: View {
         //            })
         //            .store(in: &answerQuestion.cancels)
         
-        AhobsuProvider.registerAnswer(missionId: missonData.id,
+        AhobsuProvider.registerAnswer(missionId: missionData.id,
                                       contentOrNil: text,
                                       imageOrNil: nil,
                                       completion: { wrapper in
@@ -130,7 +130,7 @@ struct AnswerInsertEssayView: View {
 
 struct AnswerInsertEssayView_Previews: PreviewProvider {
     static var previews: some View {
-        AnswerInsertEssayView(missonData: Mission(id: 1, title: "", isContent: true, isImage: true))
+        AnswerInsertEssayView(missionData: Mission(id: 1, title: "", isContent: true, isImage: true))
     }
 }
 

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionEssay/AnswerQuestionEssayView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionEssay/AnswerQuestionEssayView.swift
@@ -114,11 +114,13 @@ struct AnswerQuestionEssayView: View {
         }
         
         AhobsuProvider.updateAnswer(answerId: answerId,
+                                    missionId: missonData.id,
                                     contentOrNil: text,
                                     imageOrNil: nil,
                                     completion: { wrapper in
             if let _ = wrapper?.data {
-                self.answerRegisteredActive = true
+                self.answerRegisteredActive = false
+                self.presentationMode.wrappedValue.dismiss()
             } else {
                 
             }

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionEssay/AnswerQuestionEssayView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionEssay/AnswerQuestionEssayView.swift
@@ -22,10 +22,10 @@ struct AnswerQuestionEssayView: View {
     var answerId: Int? = nil
     
     private func getTitleItemString() -> String {
-        if self.isEdit == true {
-            return "수정하기"
+        if self.isEdit {
+            return "수정 하기"
         } else {
-            return "답변하기"
+            return "답변 하기"
         }
     }
     
@@ -36,7 +36,7 @@ struct AnswerQuestionEssayView: View {
                                                            tag: true,
                                                            selection: $answerRegisteredActive) {
                                 Button(action: {
-                                    if self.isEdit == true {
+                                    if self.isEdit {
                                         self.updateAnswer()
                                     } else {
                                         self.requestAnswer()
@@ -113,14 +113,15 @@ struct AnswerQuestionEssayView: View {
             return
         }
         
+        isLoading = true
         AhobsuProvider.updateAnswer(answerId: answerId,
                                     missionId: missionData.id,
                                     contentOrNil: text,
                                     imageOrNil: nil,
                                     completion: { wrapper in
+                                        isLoading = false
             if let _ = wrapper?.data {
-                self.answerRegisteredActive = false
-                self.presentationMode.wrappedValue.dismiss()
+                self.answerRegisteredActive = true
             } else {
                 
             }

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionEssay/AnswerQuestionEssayView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionEssay/AnswerQuestionEssayView.swift
@@ -16,13 +16,30 @@ struct AnswerQuestionEssayView: View {
     @State var answerRegisteredActive: Bool? = false
     @ObservedObject var answerQuestion = AnswerQuestion()
     
+    var isEdit: Bool = false
+    var answerId: Int? = nil
+    
+    private func getTitleItemString() -> String {
+        if self.isEdit == true {
+            return "수정하기"
+        } else {
+            return "답변하기"
+        }
+    }
+    
     var body: some View {
-        NavigationMaskingView(titleItem: Text("답변하기")
+        NavigationMaskingView(titleItem: Text(self.getTitleItemString())
                                 .font(.system(size: 16)),
                               trailingItem: NavigationLink(destination: AnswerRegisteredView(),
                                                            tag: true,
                                                            selection: $answerRegisteredActive) {
-                                Button(action: { self.requestAnswer() }) {
+                                Button(action: {
+                                    if self.isEdit == true {
+                                        self.updateAnswer()
+                                    } else {
+                                        self.requestAnswer()
+                                    }
+                                }) {
                                     Text("완료")
                                         .foregroundColor(text.isEmpty ? Color(.gray) : Color(.rosegold))
                                         .font(.system(size: 16))
@@ -82,6 +99,27 @@ struct AnswerQuestionEssayView: View {
                                         } else {
                                             // print(wrapper?.message ?? "None")
                                         }
+        }, error: { _ in
+            
+        }, expireTokenAction: {
+            
+        }, filteredStatusCode: nil)
+    }
+    
+    private func updateAnswer() {
+        guard let answerId = self.answerId else {
+            return
+        }
+        
+        AhobsuProvider.updateAnswer(answerId: answerId,
+                                    contentOrNil: text,
+                                    imageOrNil: nil,
+                                    completion: { wrapper in
+            if let _ = wrapper?.data {
+                self.answerRegisteredActive = true
+            } else {
+                
+            }
         }, error: { _ in
             
         }, expireTokenAction: {

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionEssay/AnswerQuestionEssayView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionEssay/AnswerQuestionEssayView.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 
 struct AnswerQuestionEssayView: View {
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    
     @State var text = ""
     @State var isLoading = false
     var missonData: Mission

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionEssay/AnswerQuestionEssayView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionEssay/AnswerQuestionEssayView.swift
@@ -13,7 +13,7 @@ struct AnswerQuestionEssayView: View {
     
     @State var text = ""
     @State var isLoading = false
-    var missonData: Mission
+    var missionData: Mission
     
     @State var answerRegisteredActive: Bool? = false
     @ObservedObject var answerQuestion = AnswerQuestion()
@@ -53,7 +53,7 @@ struct AnswerQuestionEssayView: View {
                 BackgroundView()
                     .ignoresSafeArea()
                 VStack(spacing: 0) {
-                    Text(missonData.title)
+                    Text(missionData.title)
                         .foregroundColor(Color(.rosegold))
                         .font(.custom("IropkeBatangOTFM", size: 20))
                         .lineSpacing(10.0)
@@ -89,7 +89,7 @@ struct AnswerQuestionEssayView: View {
     
     private func requestAnswer() {
         isLoading = true
-        AhobsuProvider.registerAnswer(missionId: missonData.id,
+        AhobsuProvider.registerAnswer(missionId: missionData.id,
                                       contentOrNil: text,
                                       imageOrNil: nil,
                                       completion: { wrapper in
@@ -114,7 +114,7 @@ struct AnswerQuestionEssayView: View {
         }
         
         AhobsuProvider.updateAnswer(answerId: answerId,
-                                    missionId: missonData.id,
+                                    missionId: missionData.id,
                                     contentOrNil: text,
                                     imageOrNil: nil,
                                     completion: { wrapper in
@@ -134,7 +134,7 @@ struct AnswerQuestionEssayView: View {
 
 struct AnswerQuestionEssayView_Previews: PreviewProvider {
     static var previews: some View {
-        AnswerQuestionEssayView(missonData: Mission(id: 0,
+        AnswerQuestionEssayView(missionData: Mission(id: 0,
                                                     title: "질문에 대한 \n답변을 해주세요",
                                                     isContent: true,
                                                     isImage: false))

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionImage/AnswerQuestionImageView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionImage/AnswerQuestionImageView.swift
@@ -23,8 +23,19 @@ struct AnswerQuestionImageView: View {
     @State var answerRegisteredActive: Bool? = false
     @ObservedObject var answerQuestion = AnswerQuestion()
     
+    var isEdit: Bool = false
+    var answerId: Int? = nil
+    
+    private func getTitleItemString() -> String {
+        if self.isEdit == true {
+            return "수정하기"
+        } else {
+            return "답변하기"
+        }
+    }
+    
     var body: some View {
-        NavigationMaskingView(titleItem: Text("답변하기")
+        NavigationMaskingView(titleItem: Text(self.getTitleItemString())
                                 .font(.system(size: 16)),
                               trailingItem: NavigationLink(destination: AnswerRegisteredView(),
                                                            tag: true,
@@ -110,6 +121,27 @@ struct AnswerQuestionImageView: View {
                                         } else {
                                             // print(wrapper?.message ?? "None")
                                         }
+        }, error: { _ in
+            
+        }, expireTokenAction: {
+            
+        }, filteredStatusCode: nil)
+    }
+    
+    private func updateAnswer() {
+        guard let answerId = self.answerId else {
+            return
+        }
+        
+        AhobsuProvider.updateAnswer(answerId: answerId,
+                                    contentOrNil: nil,
+                                    imageOrNil: image,
+                                    completion: { wrapper in
+            if let _ = wrapper?.data {
+                self.answerRegisteredActive = true
+            } else {
+                
+            }
         }, error: { _ in
             
         }, expireTokenAction: {

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionImage/AnswerQuestionImageView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionImage/AnswerQuestionImageView.swift
@@ -17,7 +17,7 @@ struct AnswerQuestionImageView: View {
     @State var showImageSourcePicker = false
     @State var isLoading = false
     
-    var missonData: Mission
+    var missionData: Mission
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     
     @State var answerRegisteredActive: Bool? = false
@@ -88,7 +88,7 @@ struct AnswerQuestionImageView: View {
                     Color(.goldbrown)
                         .frame(height: 1)
                         .frame(maxWidth: .infinity)
-                    Text(missonData.title)
+                    Text(missionData.title)
                         .foregroundColor(Color(.rosegold))
                         .font(.custom("IropkeBatangOTFM", size: 20))
                         .lineSpacing(10.0)
@@ -110,7 +110,7 @@ struct AnswerQuestionImageView: View {
     
     private func requestAnswer() {
         isLoading = true
-        AhobsuProvider.registerAnswer(missionId: missonData.id,
+        AhobsuProvider.registerAnswer(missionId: missionData.id,
                                       contentOrNil: nil,
                                       imageOrNil: image,
                                       completion: { wrapper in
@@ -134,6 +134,7 @@ struct AnswerQuestionImageView: View {
         }
         
         AhobsuProvider.updateAnswer(answerId: answerId,
+                                    missionId: missionData.id,
                                     contentOrNil: nil,
                                     imageOrNil: image,
                                     completion: { wrapper in
@@ -152,7 +153,7 @@ struct AnswerQuestionImageView: View {
 
 struct AnswerQuestionImageView_Previews: PreviewProvider {
     static var previews: some View {
-        AnswerQuestionImageView(missonData: Mission(id: 0,
+        AnswerQuestionImageView(missionData: Mission(id: 0,
                                                     title: "질문에 대한 \n답변을 해주세요",
                                                     isContent: false,
                                                     isImage: true))

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionImage/AnswerQuestionImageView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionImage/AnswerQuestionImageView.swift
@@ -28,10 +28,10 @@ struct AnswerQuestionImageView: View {
     var imageUrl: String? = nil
     
     private func getTitleItemString() -> String {
-        if self.isEdit == true {
-            return "수정하기"
+        if self.isEdit {
+            return "수정 하기"
         } else {
-            return "답변하기"
+            return "답변 하기"
         }
     }
     
@@ -41,13 +41,19 @@ struct AnswerQuestionImageView: View {
                               trailingItem: NavigationLink(destination: AnswerRegisteredView(),
                                                            tag: true,
                                                            selection: $answerRegisteredActive) {
-                                Button(action: { self.requestAnswer() }) {
+                                Button(action: {
+                                    if self.isEdit {
+                                        self.updateAnswer()
+                                    } else {
+                                        self.requestAnswer()
+                                    }
+                                }) {
                                     Text("완료")
-                                        .foregroundColor(image == nil ? Color(.gray) : Color(.rosegold))
+                                        .foregroundColor((isEdit ? false : image == nil) ? Color(.gray) : Color(.rosegold))
                                         .font(.system(size: 16))
                                 }
                               }
-                              .disabled(image == nil)
+                              .disabled(isEdit ? false : image == nil)
         ) {
             ZStack {
                 BackgroundView()
@@ -142,14 +148,15 @@ struct AnswerQuestionImageView: View {
             return
         }
         
+        isLoading = true
         AhobsuProvider.updateAnswer(answerId: answerId,
                                     missionId: missionData.id,
                                     contentOrNil: nil,
                                     imageOrNil: image,
                                     completion: { wrapper in
+                                        isLoading = false
             if let _ = wrapper?.data {
-                self.answerRegisteredActive = false
-                self.presentationMode.wrappedValue.dismiss()
+                self.answerRegisteredActive = true
             } else {
                 
             }

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionImage/AnswerQuestionImageView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQuestionImage/AnswerQuestionImageView.swift
@@ -25,6 +25,7 @@ struct AnswerQuestionImageView: View {
     
     var isEdit: Bool = false
     var answerId: Int? = nil
+    var imageUrl: String? = nil
     
     private func getTitleItemString() -> String {
         if self.isEdit == true {
@@ -60,12 +61,20 @@ struct AnswerQuestionImageView: View {
                                 self.showImageSourcePicker = true
                             }
                         Image("icCameraIncircle")
-                        Image(uiImage: image ?? UIImage())
-                            .resizable()
-                            .scaledToFill()
-                            .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.width * 4 / 3)
-                            .allowsHitTesting(false)
-                            .clipped()
+                        if let imageUrl = self.imageUrl {
+                            ImageView(withURL: imageUrl)
+                                .scaledToFill()
+                                .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.width * 4 / 3)
+                                .allowsHitTesting(false)
+                                .clipped()
+                        } else {
+                            Image(uiImage: image ?? UIImage())
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.width * 4 / 3)
+                                .allowsHitTesting(false)
+                                .clipped()
+                        }
                     }
                     .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.width * 4 / 3)
                     .clipped()
@@ -139,7 +148,8 @@ struct AnswerQuestionImageView: View {
                                     imageOrNil: image,
                                     completion: { wrapper in
             if let _ = wrapper?.data {
-                self.answerRegisteredActive = true
+                self.answerRegisteredActive = false
+                self.presentationMode.wrappedValue.dismiss()
             } else {
                 
             }

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQusetionImageEssayView/AnswerQuestionImageEssayView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQusetionImageEssayView/AnswerQuestionImageEssayView.swift
@@ -23,13 +23,30 @@ struct AnswerQuestionImageEssayView: View {
     @State var answerRegisteredActive: Bool? = false
     @ObservedObject var answerQuestion = AnswerQuestion()
     
+    var isEdit: Bool = false
+    var answerId: Int? = nil
+    
+    private func getTitleItemString() -> String {
+        if self.isEdit == true {
+            return "수정하기"
+        } else {
+            return "답변하기"
+        }
+    }
+    
     var body: some View {
-        NavigationMaskingView(titleItem: Text("답변하기")
+        NavigationMaskingView(titleItem: Text(self.getTitleItemString())
                                 .font(.system(size: 16)),
                               trailingItem: NavigationLink(destination: AnswerRegisteredView(),
                                                            tag: true,
                                                            selection: $answerRegisteredActive) {
-                                Button(action: { self.requestAnswer() }) {
+                                Button(action: {
+                                    if self.isEdit == true {
+                                        self.updateAnswer()
+                                    } else {
+                                        self.requestAnswer()
+                                    }
+                                }) {
                                     Text("완료")
                                         .foregroundColor((text.isEmpty || image == nil) ? Color(.gray) : Color(.rosegold))
                                         .font(.system(size: 16))
@@ -131,6 +148,27 @@ struct AnswerQuestionImageEssayView: View {
                                         } else {
                                             // print(wrapper?.message ?? "None")
                                         }
+        }, error: { _ in
+            
+        }, expireTokenAction: {
+            
+        }, filteredStatusCode: nil)
+    }
+    
+    private func updateAnswer() {
+        guard let answerId = self.answerId else {
+            return
+        }
+        
+        AhobsuProvider.updateAnswer(answerId: answerId,
+                                    contentOrNil: text,
+                                    imageOrNil: image,
+                                    completion: { wrapper in
+            if let _ = wrapper?.data {
+                self.answerRegisteredActive = true
+            } else {
+                
+            }
         }, error: { _ in
             
         }, expireTokenAction: {

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQusetionImageEssayView/AnswerQuestionImageEssayView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQusetionImageEssayView/AnswerQuestionImageEssayView.swift
@@ -27,6 +27,7 @@ struct AnswerQuestionImageEssayView: View {
     
     var isEdit: Bool = false
     var answerId: Int? = nil
+    var imageUrl: String? = nil
     
     private func getTitleItemString() -> String {
         if self.isEdit == true {
@@ -68,12 +69,20 @@ struct AnswerQuestionImageEssayView: View {
                                 self.showImageSourcePicker = true
                             }
                         Image("icCameraIncircle")
-                        Image(uiImage: image ?? UIImage())
-                            .resizable()
-                            .scaledToFill()
-                            .frame(width: UIScreen.main.bounds.width, height: 200)
-                            .allowsHitTesting(false)
-                            .clipped()
+                        if let imageUrl = self.imageUrl {
+                            ImageView(withURL: imageUrl)
+                                .scaledToFill()
+                                .frame(width: UIScreen.main.bounds.width, height: 200)
+                                .allowsHitTesting(false)
+                                .clipped()
+                        } else {
+                            Image(uiImage: image ?? UIImage())
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: UIScreen.main.bounds.width, height: 200)
+                                .allowsHitTesting(false)
+                                .clipped()
+                        }
                     }
                     .foregroundColor(.blue)
                     .frame(width: UIScreen.main.bounds.width, height: 200)

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQusetionImageEssayView/AnswerQuestionImageEssayView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQusetionImageEssayView/AnswerQuestionImageEssayView.swift
@@ -30,10 +30,10 @@ struct AnswerQuestionImageEssayView: View {
     var imageUrl: String? = nil
     
     private func getTitleItemString() -> String {
-        if self.isEdit == true {
-            return "수정하기"
+        if self.isEdit {
+            return "수정 하기"
         } else {
-            return "답변하기"
+            return "답변 하기"
         }
     }
     
@@ -44,18 +44,18 @@ struct AnswerQuestionImageEssayView: View {
                                                            tag: true,
                                                            selection: $answerRegisteredActive) {
                                 Button(action: {
-                                    if self.isEdit == true {
+                                    if self.isEdit {
                                         self.updateAnswer()
                                     } else {
                                         self.requestAnswer()
                                     }
                                 }) {
                                     Text("완료")
-                                        .foregroundColor((text.isEmpty || image == nil) ? Color(.gray) : Color(.rosegold))
+                                        .foregroundColor((isEdit ? text.isEmpty : text.isEmpty || image == nil) ? Color(.gray) : Color(.rosegold))
                                         .font(.system(size: 16))
                                 }
                               }
-                              .disabled(text.isEmpty || image == nil)
+                              .disabled(isEdit ? text.isEmpty : text.isEmpty || image == nil)
         ) {
             ZStack {
                 BackgroundView()
@@ -171,11 +171,13 @@ struct AnswerQuestionImageEssayView: View {
             return
         }
         
+        isLoading = true
         AhobsuProvider.updateAnswer(answerId: answerId,
                                     missionId: missionData.id,
                                     contentOrNil: text,
                                     imageOrNil: image,
                                     completion: { wrapper in
+                                        isLoading = false
             if let _ = wrapper?.data {
                 self.answerRegisteredActive = true
             } else {

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQusetionImageEssayView/AnswerQuestionImageEssayView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQusetionImageEssayView/AnswerQuestionImageEssayView.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 
 struct AnswerQuestionImageEssayView: View {
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    
     @State var image: UIImage?
     @State var showCamera: Bool = false
     @State var showImagePicker = false

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQusetionImageEssayView/AnswerQuestionImageEssayView.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/AnswerQuestion/AnswerQusetionImageEssayView/AnswerQuestionImageEssayView.swift
@@ -20,7 +20,7 @@ struct AnswerQuestionImageEssayView: View {
     @State var text = ""
     @State var isLoading = false
     
-    var missonData: Mission
+    var missionData: Mission
     
     @State var answerRegisteredActive: Bool? = false
     @ObservedObject var answerQuestion = AnswerQuestion()
@@ -96,7 +96,7 @@ struct AnswerQuestionImageEssayView: View {
                     Color(.goldbrown)
                         .frame(height: 1)
                         .frame(maxWidth: .infinity)
-                    Text(missonData.title)
+                    Text(missionData.title)
                         .foregroundColor(Color(.rosegold))
                         .font(.custom("IropkeBatangOTFM", size: 20))
                         .lineSpacing(10.0)
@@ -139,7 +139,7 @@ struct AnswerQuestionImageEssayView: View {
     
     private func requestAnswer() {
         isLoading = true
-        AhobsuProvider.registerAnswer(missionId: missonData.id,
+        AhobsuProvider.registerAnswer(missionId: missionData.id,
                                       contentOrNil: text,
                                       imageOrNil: image,
                                       completion: { wrapper in
@@ -163,6 +163,7 @@ struct AnswerQuestionImageEssayView: View {
         }
         
         AhobsuProvider.updateAnswer(answerId: answerId,
+                                    missionId: missionData.id,
                                     contentOrNil: text,
                                     imageOrNil: image,
                                     completion: { wrapper in
@@ -181,9 +182,10 @@ struct AnswerQuestionImageEssayView: View {
 
 struct AnswerQuestionImageEssayView_Previews: PreviewProvider {
     static var previews: some View {
-        AnswerQuestionImageEssayView(missonData: Mission(id: 0,
+        AnswerQuestionImageEssayView(missionData: Mission(id: 0,
                                                          title: "질문에 대한 \n답변을 해주세요",
                                                          isContent: true,
-                                                         isImage: false))
+                                                         isImage: false)
+        )
     }
 }

--- a/Ahobsu/MotiViews/Main/AnswerQuestion/SupportViews/ImagePicker.swift
+++ b/Ahobsu/MotiViews/Main/AnswerQuestion/SupportViews/ImagePicker.swift
@@ -46,7 +46,7 @@ struct ImagePicker: UIViewControllerRepresentable {
         func imagePickerController(_ picker: UIImagePickerController,
                                    didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
             if let uiImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
-                image = isFiltered ? makeFilteredImage(image: uiImage) : uiImage
+                image = isFiltered ? makeFilteredImage(uiImage: uiImage) : uiImage
                 completion?(image)
             }
             if picker.sourceType == .camera {
@@ -68,10 +68,10 @@ struct ImagePicker: UIViewControllerRepresentable {
             }
         }
         
-        private func makeFilteredImage(image: UIImage?) -> UIImage? {
-            guard let image = image,
+        private func makeFilteredImage(uiImage: UIImage?) -> UIImage? {
+            guard let image = uiImage,
                   let cgImage = image.cgImage,
-                  let sepiaFilter = CIFilter(name:"CISepiaTone") else { return image }
+                  let sepiaFilter = CIFilter(name:"CISepiaTone") else { return uiImage }
             
             let originalCIImage = CIImage(cgImage: cgImage)
 

--- a/Ahobsu/MotiViews/Main/MainView/MainView.swift
+++ b/Ahobsu/MotiViews/Main/MainView/MainView.swift
@@ -90,7 +90,7 @@ struct MainView: View {
                     VStack {
                         Spacer()
                         if model.todayCard != nil {
-                            NavigationLink(destination: AnswerCompleteView(model.cards)) {
+                            NavigationLink(destination: AnswerCompleteView(models: model.cards.compactMap({ $0 }))) {
                                 VStack(spacing: 0) {
                                     Image(model.getMainFrameImageString(isTop: true))
                                     ZStack() {

--- a/Ahobsu/MotiViews/Main/MainView/MainViewModel.swift
+++ b/Ahobsu/MotiViews/Main/MainView/MainViewModel.swift
@@ -31,10 +31,15 @@ extension MainViewModel {
     func getMultipleParts() {
         AhobsuProvider.getAnswersWeek(completion: { wrapper in
             if var answerWeek = wrapper?.data {
+                
                 let formatter = ISO8601DateFormatter()
                 formatter.formatOptions = .withFullDate
                 formatter.timeZone = TimeZone.current
-                let dateString = formatter.string(from: Date())
+                
+                let nowDate = Date()
+                let modifiedDate = Calendar.current.date(byAdding: .hour, value: -MISSION_INIT_TIME.hour, to: nowDate)!
+                
+                let dateString = formatter.string(from: modifiedDate)
                 
                 withAnimation {
                     if let lastCard = answerWeek.answers.last {

--- a/Ahobsu/MotiViews/Main/SelectQuestion/SupportViews/QuestionCardView.swift
+++ b/Ahobsu/MotiViews/Main/SelectQuestion/SupportViews/QuestionCardView.swift
@@ -47,16 +47,16 @@ struct QuestionCardView: View, Identifiable {
                 Spacer()
                 if missionData.isContent == true {
                     if missionData.isImage == true {
-                        NavigationLink(destination: AnswerQuestionImageEssayView(missonData: missionData)) {
+                        NavigationLink(destination: AnswerQuestionImageEssayView(missionData: missionData)) {
                             MainButton(title: "답변하기")
                         }.environment(\.isEnabled, !missionData.title.isEmpty)
                     } else {
-                        NavigationLink(destination: AnswerQuestionEssayView(missonData: missionData)) {
+                        NavigationLink(destination: AnswerQuestionEssayView(missionData: missionData)) {
                             MainButton(title: "답변하기")
                         }.environment(\.isEnabled, !missionData.title.isEmpty)
                     }
                 } else if missionData.isImage == true {
-                    NavigationLink(destination: AnswerQuestionImageView(missonData: missionData)) {
+                    NavigationLink(destination: AnswerQuestionImageView(missionData: missionData)) {
                         MainButton(title: "답변하기")
                     }.environment(\.isEnabled, !missionData.title.isEmpty)
                 }

--- a/Ahobsu/Networking/AhobsuAPI.swift
+++ b/Ahobsu/Networking/AhobsuAPI.swift
@@ -13,7 +13,7 @@ import Moya
 enum AhobsuAPI {
     /* Answers */
     case registerAnswer(missionId: Int, contentOrNil: String?, imageOrNil: UIImage?)
-    case updateAnswer(answerId: Int, contentOrNil: String?, imageOrNil: UIImage?)
+    case updateAnswer(answerId: Int, missionId: Int, contentOrNil: String?, imageOrNil: UIImage?)
     case getWeekAnswers
     case getAnswers(answerID: Int?)
     case getAnswer(missionDate: String)
@@ -53,7 +53,7 @@ extension AhobsuAPI: TargetType {
             /* Answers */
         case .registerAnswer:
             return "/answers"
-        case let .updateAnswer(answerId, _, _):
+        case let .updateAnswer(answerId, _, _, _):
             return "/answers/\(answerId)"
         case .getWeekAnswers:
             return "/answers/week"
@@ -141,8 +141,8 @@ extension AhobsuAPI: TargetType {
             defaultParams["missionId"] = missionId
             defaultParams["content"] = contentOrNil
             defaultParams["file"] = imageOrNil
-        case let .updateAnswer(answerId, contentOrNil, imageOrNil):
-            defaultParams["answerId"] = answerId
+        case let .updateAnswer(answerId, missionId, contentOrNil, imageOrNil):
+            defaultParams["missionId"] = missionId
             defaultParams["content"] = contentOrNil
             defaultParams["file"] = imageOrNil
         case .getWeekAnswers:
@@ -242,7 +242,7 @@ extension AhobsuAPI: TargetType {
             }
             
             return .uploadMultipart(formData)
-        case let .updateAnswer(answerId, contentOrNil, imageOrNil):
+        case let .updateAnswer(answerId, missionId, contentOrNil, imageOrNil):
             
             var formData: [MultipartFormData] = []
             formData.append(MultipartFormData(provider: .data(Data(from: answerId)),
@@ -259,20 +259,26 @@ extension AhobsuAPI: TargetType {
                                                       name: "file",
                                                       fileName: "answer.jpeg",
                                                       mimeType: "image/jpeg"))
-                    formData.append(MultipartFormData(provider: .data(Data(from: content)),
+                    formData.append(MultipartFormData(provider: .data(content.data(using: .utf8)!),
                                                       name: "content"))
+                    formData.append(MultipartFormData(provider: .data("\(missionId)".data(using: .utf8)!),
+                                                      name: "missionId"))
                 } else {
                     /* 사진 */
                     formData.append(MultipartFormData(provider: .data(imageData),
                                                       name: "file",
                                                       fileName: "answer.jpeg",
                                                       mimeType: "image/jpeg"))
+                    formData.append(MultipartFormData(provider: .data("\(missionId)".data(using: .utf8)!),
+                                                      name: "missionId"))
                 }
             } else {
                 /* 주관식 */
                 if let content = contentOrNil {
-                    formData.append(MultipartFormData(provider: .data(Data(from: content)),
+                    formData.append(MultipartFormData(provider: .data(content.data(using: .utf8)!),
                                                       name: "content"))
+                    formData.append(MultipartFormData(provider: .data("\(missionId)".data(using: .utf8)!),
+                                                      name: "missionId"))
                 } else {
                     fatalError("Both Content and Image must not be nil")
                 }

--- a/Ahobsu/Networking/AhobsuAPI.swift
+++ b/Ahobsu/Networking/AhobsuAPI.swift
@@ -141,7 +141,7 @@ extension AhobsuAPI: TargetType {
             defaultParams["missionId"] = missionId
             defaultParams["content"] = contentOrNil
             defaultParams["file"] = imageOrNil
-        case let .updateAnswer(answerId, missionId, contentOrNil, imageOrNil):
+        case let .updateAnswer(_, missionId, contentOrNil, imageOrNil):
             defaultParams["missionId"] = missionId
             defaultParams["content"] = contentOrNil
             defaultParams["file"] = imageOrNil

--- a/Ahobsu/Networking/AhobsuAPI.swift
+++ b/Ahobsu/Networking/AhobsuAPI.swift
@@ -13,7 +13,7 @@ import Moya
 enum AhobsuAPI {
     /* Answers */
     case registerAnswer(missionId: Int, contentOrNil: String?, imageOrNil: UIImage?)
-    case updateAnswer(answerId: Int, contentOrNil: String?, imageOrNil: UIImage?)
+    case updateAnswer(answerId: Int, missionId: Int, contentOrNil: String?, imageOrNil: UIImage?)
     case getWeekAnswers
     case getMonthAnswers(date: String)
     case getAnswer(missionDate: String)
@@ -53,7 +53,7 @@ extension AhobsuAPI: TargetType {
             /* Answers */
         case .registerAnswer:
             return "/answers"
-        case let .updateAnswer(answerId, _, _):
+        case let .updateAnswer(answerId, _, _, _):
             return "/answers/\(answerId)"
         case .getWeekAnswers:
             return "/answers/week"
@@ -141,8 +141,8 @@ extension AhobsuAPI: TargetType {
             defaultParams["missionId"] = missionId
             defaultParams["content"] = contentOrNil
             defaultParams["file"] = imageOrNil
-        case let .updateAnswer(answerId, contentOrNil, imageOrNil):
-            defaultParams["answerId"] = answerId
+        case let .updateAnswer(answerId, missionId, contentOrNil, imageOrNil):
+            defaultParams["missionId"] = missionId
             defaultParams["content"] = contentOrNil
             defaultParams["file"] = imageOrNil
         case .getWeekAnswers:
@@ -240,7 +240,7 @@ extension AhobsuAPI: TargetType {
             }
             
             return .uploadMultipart(formData)
-        case let .updateAnswer(answerId, contentOrNil, imageOrNil):
+        case let .updateAnswer(answerId, missionId, contentOrNil, imageOrNil):
             
             var formData: [MultipartFormData] = []
             formData.append(MultipartFormData(provider: .data(Data(from: answerId)),
@@ -257,20 +257,26 @@ extension AhobsuAPI: TargetType {
                                                       name: "file",
                                                       fileName: "answer.jpeg",
                                                       mimeType: "image/jpeg"))
-                    formData.append(MultipartFormData(provider: .data(Data(from: content)),
+                    formData.append(MultipartFormData(provider: .data(content.data(using: .utf8)!),
                                                       name: "content"))
+                    formData.append(MultipartFormData(provider: .data("\(missionId)".data(using: .utf8)!),
+                                                      name: "missionId"))
                 } else {
                     /* 사진 */
                     formData.append(MultipartFormData(provider: .data(imageData),
                                                       name: "file",
                                                       fileName: "answer.jpeg",
                                                       mimeType: "image/jpeg"))
+                    formData.append(MultipartFormData(provider: .data("\(missionId)".data(using: .utf8)!),
+                                                      name: "missionId"))
                 }
             } else {
                 /* 주관식 */
                 if let content = contentOrNil {
-                    formData.append(MultipartFormData(provider: .data(Data(from: content)),
+                    formData.append(MultipartFormData(provider: .data(content.data(using: .utf8)!),
                                                       name: "content"))
+                    formData.append(MultipartFormData(provider: .data("\(missionId)".data(using: .utf8)!),
+                                                      name: "missionId"))
                 } else {
                     fatalError("Both Content and Image must not be nil")
                 }

--- a/Ahobsu/Networking/AhobsuProvider.swift
+++ b/Ahobsu/Networking/AhobsuProvider.swift
@@ -221,6 +221,7 @@ final class AhobsuProvider {
     }
     
     class func updateAnswer(answerId: Int,
+                            missionId: Int,
                             contentOrNil: String?,
                             imageOrNil: UIImage?,
                             completion: @escaping ((APIData<Answer>?) -> Void),
@@ -228,6 +229,7 @@ final class AhobsuProvider {
                             expireTokenAction: @escaping () -> Void,
                             filteredStatusCode: [StatusEnum]?) {
         provider.request(.updateAnswer(answerId: answerId,
+                                       missionId: missionId,
                                        contentOrNil: contentOrNil,
                                        imageOrNil: imageOrNil),
                          completionHandler: { response in


### PR DESCRIPTION
## 작업 내용
* 답변 완료 화면에서 수정하기 버튼 추가
* 이미지를 사용하는 뷰에 imageUrl 필드를 새로 추가하고 주입
* 답변 완료 화면에서 답변 옵셔널을 사용하지 않도록 수정
* 답변 작성 화면에서 수정 여부를 알 수 있는 필드 추가
* 답변 작성 화면에서 수정 플로우 시 수정 API 호출
* 미션 초기화 시간 상수 설정, 수정하기 버튼 표시에 적용