### PR TITLE
답변 완료 화면에서 답변이 한 개 일 시 스크롤이 안되는 현상 해결

### DIFF
--- a/Ahobsu/Model/Answer.swift
+++ b/Ahobsu/Model/Answer.swift
@@ -95,7 +95,7 @@ extension Answer {
                        userId: 0,
                        missionId: 0,
                        imageUrl: "https://wallpapershome.com/images/pages/pic_h/11603.jpg",
-                       content: "Hello",
+                       content: "Hello\nHello\nHello\nHello\nHello\nHello\nHello\nHello\nHello\nHello\nHello\nHello\nHello\nHello\nHello\nHello\nHello\nHello\nHello\nHello",
                        date: "2020-02-01",
                        setDate: "2020-02-01",
                        mission: Mission(id: 0, title: "더미 질문", isContent: true, isImage: true),

--- a/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
+++ b/Ahobsu/MotiViews/AnswerComplete/AnswerCompleteView.swift
@@ -160,7 +160,6 @@ struct AnswerCompleteView: View {
                                      pageWidthCompensation: 0,
                                      index: $currentPage,
                                      pages: models.map { AnswerCompleteCardView(answer: $0) })
-                        .disabled(models.count == 1)
                     if models.count != 1 {
                         VStack {
                             Spacer()

--- a/Ahobsu/MotiViews/Main/SupportViews/SwiftUIPagerView.swift
+++ b/Ahobsu/MotiViews/Main/SupportViews/SwiftUIPagerView.swift
@@ -23,16 +23,17 @@ struct SwiftUIPagerView<Content: View & Identifiable>: View {
     
     var body: some View {
         GeometryReader { geometry in
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(alignment: .center, spacing: self.spacing) {
-                    ForEach(self.pages) { page in
-                        page
-                            .frame(width: geometry.size.width + self.pageWidthCompensation, height: nil)
+            if (self.pages.count > 1) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(alignment: .center, spacing: self.spacing) {
+                        ForEach(self.pages) { page in
+                            page
+                                .frame(width: geometry.size.width + self.pageWidthCompensation, height: nil)
+                        }
                     }
                 }
-            }
                 // 2
-            .content.offset(x: self.isGestureActive ? self.offset : -((geometry.size.width + self.widthCompensation) * CGFloat(self.index)))
+                .content.offset(x: self.isGestureActive ? self.offset : -((geometry.size.width + self.widthCompensation) * CGFloat(self.index)))
                 // 3
                 .frame(width: geometry.size.width, height: nil, alignment: .leading)
                 .gesture(DragGesture().onChanged({ value in
@@ -56,7 +57,11 @@ struct SwiftUIPagerView<Content: View & Identifiable>: View {
                     // 7
                     DispatchQueue.main.async { self.isGestureActive = false }
                 }))
-                .padding([.leading], -self.pageWidthCompensation)
+                .padding(.leading, -self.pageWidthCompensation)
+            } else {
+                self.pages[0]
+                    .frame(width: geometry.size.width + self.pageWidthCompensation, height: nil)
+            }
         }
     }
 }


### PR DESCRIPTION
기존에 답변 완료 뷰에서 답변이 한 개 이면, `SwiftUIPagerView` 가 `disabled` 되어 수직 스크롤이 동작하지 않는 이슈가 있음
( **앱스토어 리뷰에도 존재** )

아래 영상은 한 개 일 때는 스크롤이 안되는데, 두 개 일 때는 스크롤이 동작함.

https://github.com/mash-up-kr/Moti_iOS/assets/16275188/7ef1b3e6-b2c3-4940-a2cd-cf9b81e437eb

기존에 `disabled` 한 이유는 한 개 일 때 수평 스크롤을 막기 위함이었음.
수직 스크롤도 막기에, 수평 스크롤을 막는 로직은 `SwiftUIPagerView` 으로 스크롤뷰를 사용하지 않는 것으로 변경하였음.

수정 이후 한 개 일 때 스크롤이 동작함

https://github.com/mash-up-kr/Moti_iOS/assets/16275188/e71330ee-c55d-4fbf-a40c-2321271642d5

